### PR TITLE
Fix crash when no cohort is found

### DIFF
--- a/pkg/datasource/explore_query.go
+++ b/pkg/datasource/explore_query.go
@@ -97,7 +97,7 @@ func (ds I2b2DataSource) doCrcPsmQuery(userID string, params models.ExploreQuery
 	for _, panel := range params.Definition.Panels {
 		for i, cohortItem := range panel.CohortItems {
 			cohort, err := ds.db.GetCohort(userID, cohortItem)
-			if err != nil {
+			if err != nil || cohort == nil {
 				return "", "", fmt.Errorf("while getting cohort for doCrcPsmQuery: %v", err)
 			}
 			panel.CohortItems[i] = "patient_set_coll_id:" + strconv.FormatInt(cohort.ExploreQuery.ResultI2b2PatientSetID.Int64, 10)


### PR DESCRIPTION
Preventing the node to crash and returns an error when the cohort isn't found

Prevented crash logs:
```
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=trace msg="modifier codes are [126:1], DB operation: getModifierCodes (table name: test, path: \\\\DeathStatus-status\\\\death\\\\%, applied path: \\SPHNv2020.1\\DeathStatus\\), procedure: i2b2metadata.get_modifier_codes"
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=debug msg="successfully retrieved 1 modifier codes, DB operation: getModifierCodes (table name: test, path: \\\\DeathStatus-status\\\\death\\\\%, applied path: \\SPHNv2020.1\\DeathStatus\\), procedure: i2b2metadata.get_modifier_codes"
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=info msg="survival analysis: got concept and modifier codes"
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=info msg="survival analysis: I2B2 explore for subgroup 0"
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=trace msg="survival analysis: panels [{Not:false Timing:any CohortItems:[46238bd2-9591-443d-a0ba-bf4223bc07c9] ConceptItems:[]} {Not:false Timing:any CohortItems:[] ConceptItems:[{QueryTerm:/SPHN/SPHNv2020.1/FophDiagnosis/ Operator: Value: Type: Modifier:{Key: AppliedPath:}}]}]"
dev-local-3nodes-geco-srv0-1    | time="2022-09-13T09:35:51Z" level=warning msg="cohort not found (user ID: test, explore query ID: 46238bd2-9591-443d-a0ba-bf4223bc07c9)" node=Organization_A origin=dm
dev-local-3nodes-geco-srv0-1    | panic: runtime error: invalid memory address or nil pointer dereference
dev-local-3nodes-geco-srv0-1    | [signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x7f7d097a09ba]
dev-local-3nodes-geco-srv0-1    | 
dev-local-3nodes-geco-srv0-1    | goroutine 2478 [running]:
dev-local-3nodes-geco-srv0-1    | github.com/tuneinsight/geco-i2b2-data-source/pkg/datasource.I2b2DataSource.doCrcPsmQuery({{0xc0017daf70, 0xc0010f1fc0}, {0x2da4190, 0xc00014a460}, 0xc000b52a80, 0xc0007e1980, {{0x2da4190, 0xc00014a460}, {{0xc000d71d00, 0x20}, ...}}, ...}, ...)
dev-local-3nodes-geco-srv0-1    |       app/geco-i2b2-plugin/pkg/datasource/explore_query.go:103 +0x99a
dev-local-3nodes-geco-srv0-1    | github.com/tuneinsight/geco-i2b2-data-source/pkg/datasource.I2b2DataSource.ExploreQuery({{0xc0017daf70, 0xc0010f1fc0}, {0x2da4190, 0xc00014a460}, 0xc000b52a80, 0xc0007e1980, {{0x2da4190, 0xc00014a460}, {{0xc000d71d00, 0x20}, ...}}, ...}, ...)
dev-local-3nodes-geco-srv0-1    |       app/geco-i2b2-plugin/pkg/datasource/explore_query.go:71 +0xc9
dev-local-3nodes-geco-srv0-1    | github.com/tuneinsight/geco-i2b2-data-source/pkg/datasource.I2b2DataSource.SurvivalQuery.func1(0x0, 0xc0011b4440)
dev-local-3nodes-geco-srv0-1    |       app/geco-i2b2-plugin/pkg/datasource/survival_query.go:131 +0x5c5
dev-local-3nodes-geco-srv0-1    | created by github.com/tuneinsight/geco-i2b2-data-source/pkg/datasource.I2b2DataSource.SurvivalQuery
dev-local-3nodes-geco-srv0-1    |       app/geco-i2b2-plugin/pkg/datasource/survival_query.go:122 +0x9ad
```